### PR TITLE
Fix parser error with prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ This project implements a distributed transactional database based on the Cockro
 3. Run `go mod download` to fetch dependencies
 4. Run `go build ./...` to build all components
 
+# Create a table
+curl -X POST http://localhost:8080/execute -d '{"query": "CREATE TABLE users (id INT, name VARCHAR(255))"}'
+
+# Insert data
+curl -X POST http://localhost:8080/execute -d '{"query": "INSERT INTO users (id, name) VALUES (1, \"John\")"}'
+
+# Query data
+curl -X POST http://localhost:8080/execute -d '{"query": "SELECT * FROM users"}'
+
+# Check health
+curl http://localhost:8080/health
+
 ## Development Status
 
 This is a work in progress. Currently implementing core components of the distributed database system. 

--- a/internal/sql/executor.go
+++ b/internal/sql/executor.go
@@ -13,9 +13,9 @@ import (
 
 // Executor represents the SQL execution engine
 type Executor struct {
-	storage  storage.Engine
-	txns     *transaction.TransactionManager
-	schemas  map[string]*TableSchema
+	storage   storage.Engine
+	txns      *transaction.TransactionManager
+	schemas   map[string]*TableSchema
 	schemasMu sync.RWMutex
 }
 
@@ -103,10 +103,23 @@ func (e *Executor) executeCreateTable(ctx context.Context, txn *transaction.Tran
 			return fmt.Errorf("invalid column definition: %s", col)
 		}
 
+		// Extract column name and type
+		name := parts[0]
+		dataType := parts[1]
+
+		// Check for additional constraints
+		nullable := true
+		for j := 2; j < len(parts); j++ {
+			if strings.ToLower(parts[j]) == "not" && j+1 < len(parts) && strings.ToLower(parts[j+1]) == "null" {
+				nullable = false
+				break
+			}
+		}
+
 		schema.Columns[i] = Column{
-			Name:     parts[0],
-			Type:     parts[1],
-			Nullable: strings.Contains(strings.ToLower(col), "nullable"),
+			Name:     name,
+			Type:     dataType,
+			Nullable: nullable,
 		}
 	}
 
@@ -223,4 +236,4 @@ func (e *Executor) executeDelete(ctx context.Context, txn *transaction.Transacti
 	}
 
 	return nil
-} 
+}


### PR DESCRIPTION
Cursor (chatgpt 4o mini) correctly deduced that there was an error in the parser that prevented column definitions from being parsed.

<img width="1191" alt="image" src="https://github.com/user-attachments/assets/e10597fd-baa4-42fb-9058-7847473c784c" />

<img width="1191" alt="image" src="https://github.com/user-attachments/assets/d717c5a4-2606-4f25-aa0d-bc440882df90" />

<img width="1191" alt="image" src="https://github.com/user-attachments/assets/e6eca06a-5405-46cb-ba64-1ff6c824c1c6" />
